### PR TITLE
Allow another process (eg Vault Agent)

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ If your configuration is right and Vault is running on the same host as the agen
 
 `approle` Specifies the approle name used to login.  Defaults to "approle".
 
+`token_path` Specifies the path to a file containing a Vault token, if one exists (e.g. a Vault Agent might already be running along the Vault Server, and it writes a token to the Sink file path). If this is specified, approle authentication is skipped. This token must have a policy with at least the permissions described in the authentication section.
+
 ### Storage options
 
 Note that if you specify more than one storage option, *all* options will be written to.  For example, specifying `local_storage` and `aws_storage` will write to both locations.
@@ -118,7 +120,7 @@ Note that if you specify more than one storage option, *all* options will be wri
 
 ## Authentication
 
-You must do some quick initial setup prior to being able to use the Snapshot Agent.  This involves the following:
+Unless another process like a Vault Agent is providing the Snapshot Agent with a token (specified via the `token_path` configuration), you must do some quick initial setup prior to being able to use the Snapshot Agent.  This involves the following:
 
 `vault login` with an admin user.
 Create the following policy `vault policy write snapshot ./my_policies/snapshot_policy.hcl`

--- a/config/config.go
+++ b/config/config.go
@@ -21,6 +21,7 @@ type Configuration struct {
 	RoleID    string      `json:"role_id"`
 	SecretID  string      `json:"secret_id"`
 	Approle   string      `json:"approle"`
+	TokenPath string      `json:"token_path"`
 }
 
 // AzureConfig is the configuration for Azure blob snapshots

--- a/main.go
+++ b/main.go
@@ -46,7 +46,7 @@ func main() {
 
 	for {
 		if snapshotter.TokenExpiration.Before(time.Now()) {
-			snapshotter.SetClientTokenFromAppRole(c)
+			snapshotter.SetClientToken(c)
 		}
 		leader, err := snapshotter.API.Sys().Leader()
 		if err != nil {
@@ -54,7 +54,7 @@ func main() {
 			log.Fatalln("Unable to determine leader instance.  The snapshot agent will only run on the leader node.  Are you running this daemon on a Vault instance?")
 		}
 		leaderIsSelf := leader.IsSelf
-		if ! leaderIsSelf {
+		if !leaderIsSelf {
 			log.Println("Not running on leader node, skipping.")
 		} else {
 			var snapshot bytes.Buffer


### PR DESCRIPTION
Hello Lucretius! I have a Vault setup such that a Vault Agent process is already running next to my Vault Server nodes. This Vault Agent uses auto_auth with AWS, and writes a token to a sink file. I wanted to have your raft snapshot agent use that token, instead of authenticate via approle. I made a couple minor additions and figured I'd create a pull request in case it's worth adding to your project. 

VSCode did some auto formatting which formatted a couple spots that I otherwise would not have touched. I can undo those if this is something you want to pull into your project